### PR TITLE
Update format_disk.sh

### DIFF
--- a/scripts/format_disk.sh
+++ b/scripts/format_disk.sh
@@ -2,9 +2,16 @@
 
 DISK=$1;
 
-echo -n "Formatting disk ${DISK}..."
+getmsize() { echo $(expr $(diskinfo -v $1 | grep bytes | cut -d \# -f 1) / 1024 / 1024  ) ; }
+
+DISKSIZE=$( getmsize ${DISK} );
+
+echo  "Erasing partitions on disk ${DISK}...${DISKSIZE}M"
 /bin/dd if=/dev/zero of=/dev/${DISK} bs=1m count=1
 RV=$?
+
+#echo  "Erasing backup GPT on disk ${DISK}...${DISKSIZE}M"
+/bin/dd if=/dev/zero of=/dev/${DISK} bs=1m seek=$((${DISKSIZE}-2))
 
 if [ "$RV" = "0" ]
 then


### PR DESCRIPTION
Also erase the backup GPT table or hardware RAID information at the end of the disk.

I had proposed this to Jason years ago, just before he handed over the project, but it never made it in. 
Eliminates an occasional error where the system keeps using the backup GPT which prevents re-labeling.
This uses the traditional base-2 megabyte, consistent with dd expectations.